### PR TITLE
de10lite board minor changes and MiST boards set mist 1

### DIFF
--- a/Board/de10lite/constraints.sdc
+++ b/Board/de10lite/constraints.sdc
@@ -17,6 +17,7 @@ set VGA_OUT {VGA_R[*] VGA_G[*] VGA_B[*] VGA_HS VGA_VS}
 set FALSE_OUT {ARDUINO_IO[*] GPIO[*] LEDR[*] }
 set FALSE_IN {ARDUINO_IO[*] GPIO[*] KEY[*]}
 
+# JTAG constraints for debug interface (if enabled)
 # create_clock -name {altera_reserved_tck} -period 40 {altera_reserved_tck}
 set_input_delay -clock altera_reserved_tck -clock_fall 3 altera_reserved_tdi
 set_input_delay -clock altera_reserved_tck -clock_fall 3 altera_reserved_tms

--- a/Board/de10lite/de10lite_opts.tcl
+++ b/Board/de10lite/de10lite_opts.tcl
@@ -23,6 +23,8 @@ set_global_assignment -name OUTPUT_IO_TIMING_NEAR_END_VMEAS "HALF VCCIO" -fall
 set_global_assignment -name OUTPUT_IO_TIMING_FAR_END_VMEAS "HALF SIGNAL SWING" -rise
 set_global_assignment -name OUTPUT_IO_TIMING_FAR_END_VMEAS "HALF SIGNAL SWING" -fall
 set_global_assignment -name STRATIX_DEVICE_IO_STANDARD "2.5 V"
+set_global_assignment -name NUM_PARALLEL_PROCESSORS ALL
+set_global_assignment -name GENERATE_SVF_FILE ON
 
 if {[info exists optimizeforspeed] && ($optimizeforspeed==1)} {
 	set_global_assignment -name OPTIMIZATION_MODE "AGGRESSIVE PERFORMANCE"

--- a/Board/de10lite/de10lite_pins.tcl
+++ b/Board/de10lite/de10lite_pins.tcl
@@ -451,8 +451,8 @@ set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[32]
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[33]
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[34]
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to GPIO[35]
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to CLK_I2C_SCL
-set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to CLK_I2C_SDA
+#set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to CLK_I2C_SCL
+#set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to CLK_I2C_SDA
 
 set_location_assignment PIN_V10 -to GPIO[0]
 set_location_assignment PIN_W10 -to GPIO[1]

--- a/Board/mist/constraints.sdc
+++ b/Board/mist/constraints.sdc
@@ -4,6 +4,8 @@ create_clock -name clock27_0 -period 37.037 [get_ports {CLOCK_27[0]}]
 create_clock -name clock27 -period 37.037 [get_ports {CLOCK_27}]
 create_clock -name spiclk  -period 41.666 -waveform { 20.8 41.666 } [get_ports {SPI_SCK}]
 
+set mist 1
+
 set hostclk { clock27 }
 set supportclk { clock27 }
 

--- a/Board/sidi/constraints.sdc
+++ b/Board/sidi/constraints.sdc
@@ -3,6 +3,8 @@ set_time_format -unit ns -decimal_places 3
 create_clock -name clock27 -period 37.037 [get_ports {CLOCK_27}]
 create_clock -name {spiclk}  -period 41.666 -waveform { 20.8 41.666 } [get_ports {SPI_SCK}]
 
+set mist 1
+
 set hostclk { clock27 }
 set supportclk { clock27 }
 

--- a/templates/de10lite/de10lite_top.vhd
+++ b/templates/de10lite/de10lite_top.vhd
@@ -188,8 +188,8 @@ VGA_VS<=vga_vsync;
 guest: COMPONENT guest_top
 	PORT map
 	(
-		CLOCK_27 => MAX10_CLK2_50&MAX10_CLK2_50, -- Comment out one of these lines to match the guest core.
-		CLOCK_27 => MAX10_CLK2_50,
+		CLOCK_27 => MAX10_CLK1_50&MAX10_CLK1_50, -- Comment out one of these lines to match the guest core.
+		CLOCK_27 => MAX10_CLK1_50,
 --		RESET_N => reset_n,
 		-- clocks
 		SDRAM_DQ => DRAM_DQ,


### PR DESCRIPTION
Added set mist 1 in MiST board as a way to differentiate constraints depending if it's a miST or not miST board (I used it in the PCXT core)

Minor changes in de10lite board. Check if you agree.